### PR TITLE
Use Google maps API release version

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <link rel="stylesheet" type="text/css" href="turkuBus.css">
     <script async defer
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBA_5e41VXdcifIbmZ8iRVzqyMuEwiReQo&callback=initMap">
+            src="https://maps.googleapis.com/maps/api/js?v=3&key=AIzaSyBA_5e41VXdcifIbmZ8iRVzqyMuEwiReQo&callback=initMap">
     </script>
 
     <script>


### PR DESCRIPTION
Changed Google maps to use the release version (v=3). This way it should
always get the release version of google maps.

https://developers.google.com/maps/documentation/javascript/versions#best-practices
